### PR TITLE
Correct example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can also add `jsonb` with the same interface.
 
 ```clojure
 (ns your-namespace.foo
-    (:require postgre-types.json :refer [add-jsonb-type]))
+    (:require [postgre-types.json :refer [add-jsonb-type]]))
 
 (add-jsonb-type f-write-json f-read-json)
 


### PR DESCRIPTION
":require" form in ns requires vector to use ":refer".
