### PR TITLE
Change name of project to postgres-json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# postgre-types
+# postgres-json
 
 A Clojure library designed to let jdbc talk the PostgresSQL json type.
 
 ## Install
 
-[![Clojars Project](http://clojars.org/postgre-types/latest-version.svg)](http://clojars.org/postgre-types)
+[![Clojars Project](http://clojars.org/postgres-json/latest-version.svg)](http://clojars.org/postgres-json)
 
 ## Usage
 
 ```clojure
 (ns your-namespace.foo
-    (:require [postgre-types.json :refer [add-json-type]]))
+    (:require [postgres-json.json :refer [add-json-type]]))
 
 (add-json-type f-write-json f-read-json)
 
@@ -22,7 +22,7 @@ You can also add `jsonb` with the same interface.
 
 ```clojure
 (ns your-namespace.foo
-    (:require [postgre-types.json :refer [add-jsonb-type]]))
+    (:require [postgres-json.json :refer [add-jsonb-type]]))
 
 (add-jsonb-type f-write-json f-read-json)
 

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject postgre-types "0.0.4"
+(defproject postgres-json "0.0.4"
   :description "Integration with PostgresSQL multiple types"
-  :url "https://github.com/siscia/postgres-type"
+  :url "https://github.com/ecbrown/postgres-json"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/java.jdbc "0.3.6"]
                  [org.postgresql/postgresql "9.4-1201-jdbc41"]]
-  :repositories [["release" "https://clojars.org/siscia"]]
+  :repositories [#_["release" "https://clojars.org/siscia"]]
   :profiles {:dev {:dependencies [[cheshire "5.3.1"]]}})

--- a/src/postgres_json/json.clj
+++ b/src/postgres_json/json.clj
@@ -8,7 +8,7 @@
 
 
 (ns ^{:author "Simone Mosciatti"}
-  postgre-types.json
+  postgres-json.json
   (:require [clojure.java.jdbc :as jdbc])
   (:import org.postgresql.util.PGobject))
 

--- a/test/postgres_json/core_test.clj
+++ b/test/postgres_json/core_test.clj
@@ -1,7 +1,7 @@
-(ns postgre-types.core-test
+(ns postgres-json.core-test
   (:require [clojure.test :refer :all]
             [clojure.java.jdbc :as j]
-            [postgre-types.json :refer [add-json-type add-jsonb-type]]
+            [postgres-json.json :refer [add-json-type add-jsonb-type]]
             [cheshire.core :refer [generate-string parse-string]]))
 
 (def db-spec {:classname "org.postgresql.Driver"


### PR DESCRIPTION
An excellent project that serves its purpose well. On another comment, it was suggested to use a different naming scheme, basically changing its name to postgres-json.  I simply walked through the code and changed names to reflect this.  Current proposal passes tests.